### PR TITLE
check with GCN page validity of current types

### DIFF
--- a/gcn/notice_types.py
+++ b/gcn/notice_types.py
@@ -164,8 +164,7 @@ _notice_types = dict(
     AMON_NU_EM_COINC=172,
     ICECUBE_ASTROTRACK_GOLD=173,
     ICECUBE_ASTROTRACK_BRONZE=174,
-    ICECUBE_CASCADE=176,
-    )
+    ICECUBE_CASCADE=176)
 
 vars().update(**_notice_types)
 NoticeType = IntEnum('NoticeType', _notice_types)

--- a/gcn/notice_types.py
+++ b/gcn/notice_types.py
@@ -161,8 +161,11 @@ _notice_types = dict(
     GWHEN_COINC=168,
     AMON_ICECUBE_EHE=169,
     HAWC_BURST_MONITOR=171,
+    AMON_NU_EM_COINC=172,
     ICECUBE_ASTROTRACK_GOLD=173,
-    ICECUBE_ASTROTRACK_BRONZE=174)
+    ICECUBE_ASTROTRACK_BRONZE=174,
+    ICECUBE_CASCADE=176,
+    )
 
 vars().update(**_notice_types)
 NoticeType = IntEnum('NoticeType', _notice_types)

--- a/gcn/tests/test_included_notice_types.py
+++ b/gcn/tests/test_included_notice_types.py
@@ -1,0 +1,21 @@
+from .. import notice_types
+
+
+def test_included_notice_types():
+    import requests
+    import re
+
+    for notice_id, notice_name in re.findall(
+            r"^<tr.*?><th>(.*?)</th><th>(.*?)</th><th>.*?ACTIVE</th>",
+            requests.get("https://gcn.gsfc.nasa.gov/filtering.html").text,
+            re.M,
+            ):
+
+        if notice_name in ("VOE_1.1_IM_ALIVE", "VOE_2.0_IM_ALIVE"):
+            continue
+
+        if notice_name in ("LVC_PRELIM", "LVC_CNTRPART"):
+            print("why are these shorter versions, and do we care?")
+            continue
+
+        assert int(notice_id) == getattr(notice_types, notice_name)

--- a/gcn/tests/test_included_notice_types.py
+++ b/gcn/tests/test_included_notice_types.py
@@ -1,9 +1,14 @@
+import pytest
+import requests
+import re
+import os
+
 from .. import notice_types
 
 
+@pytest.mark.skipif('PYTEST_NETWORK_ACCESS' not in os.environ, 
+                    reason="tests with network access disabled by defaulf, set PYTEST_NETWORK_ACCESS to enable")
 def test_included_notice_types():
-    import requests
-    import re
 
     for notice_id, notice_name in re.findall(
             r"^<tr.*?><th>(.*?)</th><th>(.*?)</th><th>.*?ACTIVE</th>",

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     six
 tests_require =
     pytest
+    requests
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Extracted more impactful change from #17: testing if included notice types are compatible with those declared by [the GCN](https://gcn.gsfc.nasa.gov/filtering.html).

New test requires network access, and is skipped by default, unless enabled by an environment variable (though maybe one can opt for a different way to enable it).